### PR TITLE
Fix Helm endpoint and test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ helm install image-converter ./infra/helm-chart \
 - `PYTHONPATH`: Python 모듈 경로 (기본값: `/app`)
 
 #### Frontend
-- `REACT_APP_API_URL`: 백엔드 API URL (기본값: `http://localhost:8000`)
+- `REACT_APP_API_URL`: 백엔드 API URL (기본값: `/api`)
+- `BACKEND_ENDPOINT`: 프록시가 요청을 전달할 백엔드 서비스 주소
+  - Docker Compose: `http://backend:8000/api`
+  - Helm: `http://image-converter-backend:8000/api`
 
 ### 도메인 설정
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       backend:
         condition: service_healthy
     environment:
-      - REACT_APP_API_URL=http://localhost:8000
-      - BACKEND_ENDPOINT=http://backend:8000
+      - REACT_APP_API_URL=/api
+      - BACKEND_ENDPOINT=http://backend:8000/api
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80"]
       interval: 15s

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=build /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 
 # 기본 백엔드 엔드포인트
-ENV BACKEND_ENDPOINT=http://localhost:8000
+ENV BACKEND_ENDPOINT=http://localhost:8000/api
 
 # 포트 노출
 EXPOSE 80

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -82,7 +82,8 @@ npm run format
 ### 환경 변수
 ```bash
 # .env.local
-REACT_APP_API_URL=http://localhost:8000
+REACT_APP_API_URL=/api
+BACKEND_ENDPOINT=http://backend:8000/api
 ```
 
 ## 📱 주요 기능
@@ -194,6 +195,7 @@ docker build -t image-converter-frontend .
 
 1. **API 연결 오류**
    - `REACT_APP_API_URL` 환경 변수 확인
+   - `BACKEND_ENDPOINT` 값이 올바른지 확인
    - 백엔드 서버 실행 상태 확인
 
 2. **파일 업로드 실패**

--- a/frontend/src/services/imageService.ts
+++ b/frontend/src/services/imageService.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { ConversionOptions } from '../stores/imageStore';
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
 
 // 테스트 환경에서 사용할 수 있도록 export
 export const apiClient = axios.create({

--- a/infra/helm-chart/kkamji_values.yaml
+++ b/infra/helm-chart/kkamji_values.yaml
@@ -59,9 +59,9 @@ frontend:
   
   env:
     - name: REACT_APP_API_URL
-      value: "http://image-convertor-backend.image-convertor.svc.cluster.local:8000"
+      value: "/api"
     - name: BACKEND_ENDPOINT
-      value: "http://image-convertor-backend:8000"
+      value: "http://image-converter-backend:8000/api"
 
 ingress:
   enabled: true

--- a/infra/helm-chart/values.yaml
+++ b/infra/helm-chart/values.yaml
@@ -57,9 +57,9 @@ frontend:
   
   env:
     - name: REACT_APP_API_URL
-      value: "http://image-convertor-backend:8000"
+      value: "/api"
     - name: BACKEND_ENDPOINT
-      value: "http://image-convertor-backend:8000"
+      value: "http://image-converter-backend:8000/api"
 
 ingress:
   enabled: true

--- a/run_and_test.sh
+++ b/run_and_test.sh
@@ -64,18 +64,14 @@ cd backend
 
 if command -v uv &> /dev/null; then
     log_info "uv로 의존성 설치 중..."
-    
-    # CI 환경에서는 시스템에 직접 설치, 로컬에서는 가상환경 사용
-    if [ "$CI" = "true" ] || [ "$GITHUB_ACTIONS" = "true" ] || [ "$GITLAB_CI" = "true" ]; then
-        uv pip install --system -e ".[dev]" || log_error "Backend 의존성 설치 실패"
-    else
-        # 로컬 환경: 가상환경이 없으면 생성
-        if [ ! -d ".venv" ]; then
-            log_info "가상환경 생성 중..."
-            uv venv
-        fi
-        uv pip install -e ".[dev]" || log_error "Backend 의존성 설치 실패"
+
+    # 로컬 가상환경 생성 후 의존성 설치
+    if [ ! -d ".venv" ]; then
+        uv venv
     fi
+    uv pip install -r requirements.txt || log_error "Backend 의존성 설치 실패"
+    uv pip install -r requirements-dev.txt || log_error "Backend dev 의존성 설치 실패"
+    source .venv/bin/activate
     
     log_info "Backend 테스트 실행 중..."
     timeout $TIMEOUT pytest -v --tb=short || log_error "Backend 테스트 실패"


### PR DESCRIPTION
## Summary
- use correct backend service name in Helm values
- clarify `BACKEND_ENDPOINT` documentation for Helm deployments
- restore local virtualenv usage in `run_and_test.sh`

## Testing
- `npm run format:check`
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `./run_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685044cc90dc8320a2644bf44c2dcda3